### PR TITLE
updated Event::Fire to Event::Dispatch

### DIFF
--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -31,8 +31,8 @@ trait Friendable
         ]);
 
         $this->friends()->save($friendship);
-      
-        Event::fire('friendships.sent', [$this, $recipient]);
+
+        Event::dispatch('friendships.sent', [$this, $recipient]);
 
         return $friendship;
 
@@ -47,7 +47,7 @@ trait Friendable
     {
         $deleted = $this->findFriendship($recipient)->delete();
 
-        Event::fire('friendships.cancelled', [$this, $recipient]);
+        Event::dispatch('friendships.cancelled', [$this, $recipient]);
 
         return $deleted;
     }
@@ -93,8 +93,8 @@ trait Friendable
             'status' => Status::ACCEPTED,
         ]);
 
-        Event::fire('friendships.accepted', [$this, $recipient]);
-      
+        Event::dispatch('friendships.accepted', [$this, $recipient]);
+
         return $updated;
     }
 
@@ -109,8 +109,8 @@ trait Friendable
             'status' => Status::DENIED,
         ]);
 
-        Event::fire('friendships.denied', [$this, $recipient]);
-      
+        Event::dispatch('friendships.denied', [$this, $recipient]);
+
         return $updated;
     }
 
@@ -188,10 +188,10 @@ trait Friendable
         $friendship = (new Friendship)->fillRecipient($recipient)->fill([
             'status' => Status::BLOCKED,
         ]);
-      
+
         $this->friends()->save($friendship);
 
-        Event::fire('friendships.blocked', [$this, $recipient]);
+        Event::dispatch('friendships.blocked', [$this, $recipient]);
 
         return $friendship;
     }
@@ -205,8 +205,8 @@ trait Friendable
     {
         $deleted = $this->findFriendship($recipient)->whereSender($this)->delete();
 
-        Event::fire('friendships.unblocked', [$this, $recipient]);
-      
+        Event::dispatch('friendships.unblocked', [$this, $recipient]);
+
         return $deleted;
     }
 
@@ -312,7 +312,7 @@ trait Friendable
     {
         return $this->getOrPaginate($this->getFriendsQueryBuilder($groupSlug), $perPage);
     }
-    
+
     /**
      * This method will not return Friendship models
      * It will return the 'friends' models. ex: App\User
@@ -325,7 +325,7 @@ trait Friendable
     {
         return $this->getOrPaginate($this->getMutualFriendsQueryBuilder($other), $perPage);
     }
-    
+
     /**
      * Get the number of friends
      *
@@ -438,7 +438,7 @@ trait Friendable
 
         return $this->where('id', '!=', $this->getKey())->whereIn('id', array_merge($recipients, $senders));
     }
-    
+
     /**
      * Get the query builder of the 'friend' model
      *

--- a/tests/FriendshipsEventsTest.php
+++ b/tests/FriendshipsEventsTest.php
@@ -11,34 +11,34 @@ use Mockery;
 class FriendshipsEventsTest extends TestCase
 {
     // use DatabaseTransactions;
-    
-    public function setUp()
+
+    public function setUp(): void
     {
         parent::setUp();
-        
+
         $this->sender    = createUser();
         $this->recipient = createUser();
     }
-  
-    public function tearDown()
+
+    public function tearDown(): void
     {
         Mockery::close();
     }
-  
+
     /** @test */
     public function friend_request_is_sent()
     {
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.sent', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.sent', Mockery::any()]);
+
         $this->sender->befriend($this->recipient);
     }
-  
+
     /** @test */
     public function friend_request_is_accepted()
     {
         $this->sender->befriend($this->recipient);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.accepted', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.accepted', Mockery::any()]);
+
         $this->recipient->acceptFriendRequest($this->sender);
     }
 
@@ -46,8 +46,8 @@ class FriendshipsEventsTest extends TestCase
     public function friend_request_is_denied()
     {
         $this->sender->befriend($this->recipient);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.denied', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.denied', Mockery::any()]);
+
         $this->recipient->denyFriendRequest($this->sender);
     }
 
@@ -56,29 +56,29 @@ class FriendshipsEventsTest extends TestCase
     {
         $this->sender->befriend($this->recipient);
         $this->recipient->acceptFriendRequest($this->sender);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.blocked', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.blocked', Mockery::any()]);
+
         $this->recipient->blockFriend($this->sender);
     }
-  
+
     /** @test */
     public function friend_is_unblocked()
     {
         $this->sender->befriend($this->recipient);
         $this->recipient->acceptFriendRequest($this->sender);
         $this->recipient->blockFriend($this->sender);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.unblocked', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.unblocked', Mockery::any()]);
+
         $this->recipient->unblockFriend($this->sender);
     }
-  
+
     /** @test */
     public function friendship_is_cancelled()
     {
         $this->sender->befriend($this->recipient);
         $this->recipient->acceptFriendRequest($this->sender);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.cancelled', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.cancelled', Mockery::any()]);
+
         $this->recipient->unfriend($this->sender);
     }
 }

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -12,59 +12,59 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class FriendshipsGroupsTest extends TestCase
 {
     use DatabaseTransactions;
-    
-    
+
+
     /** @test */
     public function user_can_add_a_friend_to_a_group()
     {
-        
+
         $sender    = createUser();
         $recipient = createUser();
-        
+
         $sender->befriend($recipient);
         $recipient->acceptFriendRequest($sender);
-        
-        $this->assertTrue((boolean)$recipient->groupFriend($sender, 'acquaintances'));
-        $this->assertTrue((boolean)$sender->groupFriend($recipient, 'family'));
-        
+
+        $this->assertTrue((bool)$recipient->groupFriend($sender, 'acquaintances'));
+        $this->assertTrue((bool)$sender->groupFriend($recipient, 'family'));
+
         // it only adds a friend to a group once
-        $this->assertFalse((boolean)$sender->groupFriend($recipient, 'family'));
-        
+        $this->assertFalse((bool)$sender->groupFriend($recipient, 'family'));
+
         // expect that users have been attached to specified groups
         $this->assertCount(1, $sender->getFriends(0, 'family'));
         $this->assertCount(1, $recipient->getFriends(0, 'acquaintances'));
-    
+
         $this->assertEquals($recipient->id, $sender->getFriends(0, 'family')->first()->id);
         $this->assertEquals($sender->id, $recipient->getFriends(0, 'acquaintances')->first()->id);
-        
+
     }
-    
+
     /** @test */
     public function user_cannot_add_a_non_friend_to_a_group()
     {
         $sender   = createUser();
         $stranger = createUser();
-        
-        $this->assertFalse((boolean)$sender->groupFriend($stranger, 'family'));
+
+        $this->assertFalse((bool)$sender->groupFriend($stranger, 'family'));
         $this->assertCount(0, $sender->getFriends(0, 'family'));
     }
-    
+
     /** @test */
     public function user_can_remove_a_friend_from_group()
     {
         $sender    = createUser();
         $recipient = createUser();
-        
+
         $sender->befriend($recipient);
         $recipient->acceptFriendRequest($sender);
-    
+
         $recipient->groupFriend($sender, 'acquaintances');
         $recipient->groupFriend($sender, 'family');
-        
+
         $this->assertEquals(1, $recipient->ungroupFriend($sender, 'acquaintances'));
-        
+
         $this->assertCount(0, $sender->getFriends(0, 'acquaintances'));
-        
+
         // expect that friend has been removed from acquaintances but not family
         $this->assertCount(0, $recipient->getFriends(0, 'acquaintances'));
         $this->assertCount(1, $recipient->getFriends(0, 'family'));
@@ -88,36 +88,36 @@ class FriendshipsGroupsTest extends TestCase
     {
         $sender    = createUser();
         $recipient = createUser();
-        
+
         $sender->befriend($recipient);
         $recipient->acceptFriendRequest($sender);
-        
+
         $sender->groupFriend($recipient, 'family');
         $sender->groupFriend($recipient, 'acquaintances');
-    
+
         $sender->ungroupFriend($recipient);
-        
+
         $this->assertCount(0, $sender->getFriends(0, 'family'));
         $this->assertCount(0, $sender->getFriends(0, 'acquaintances'));
     }
-    
+
     /** @test */
     public function it_returns_friends_of_a_group()
     {
         $sender     = createUser();
         $recipients = createUser([], 10);
-        
+
         foreach ($recipients as $key => $recipient) {
-            
+
             $sender->befriend($recipient);
             $recipient->acceptFriendRequest($sender);
-            
+
             if ($key % 2 === 0) {
                 $sender->groupFriend($recipient, 'family');
             }
-            
+
         }
-        
+
         $this->assertCount(5, $sender->getFriends(0, 'family'));
         $this->assertCount(10, $sender->getFriends());
     }
@@ -243,5 +243,5 @@ class FriendshipsGroupsTest extends TestCase
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends(0, 'acquaintances'));
     }
 
-    
+
 }


### PR DESCRIPTION
As of Laravel `5.8` the deprecated (since `5.4`) function `Illuminate\Events\Dispatcher::fire` has been removed and [should be replaced](https://github.com/laravel/framework/pull/26392) with the `dispatch` method.